### PR TITLE
feat: Add index fields, edit request timeout

### DIFF
--- a/src/main/java/com/dellin/mondoc/jobs/OrderJob.java
+++ b/src/main/java/com/dellin/mondoc/jobs/OrderJob.java
@@ -45,7 +45,7 @@ public class OrderJob {
 	//	@Scheduled(fixedDelay = 1000000L, initialDelay = 0)
 	public void getOrders() throws IOException {
 		
-		log.info("Scheduled method [getOrders] started to work");
+		log.info("Scheduled method [getOrders()] started to work");
 		
 		Date programStart = new Date();
 		
@@ -80,7 +80,8 @@ public class OrderJob {
 			public void run() {
 				
 				if (currentPage <= totalPages) {
-					log.info("Starting cycle of updating orders at {} page", currentPage);
+					log.info("Starting cycle of updating orders at [{}] page",
+							currentPage);
 					requestBuilder.setPage(currentPage);
 					
 					Date start = new Date();
@@ -90,7 +91,7 @@ public class OrderJob {
 							orderService.getRemoteData().update(requestBuilder.build());
 					try {
 						Response<OrderResponse> orderResponse = orders.execute();
-						log.info("Got the response in {} ms",
+						log.info("Got the response in [{}] sec",
 								(new Date().getTime() - start.getTime()) / 1000.);
 			
 					/* STEP THREE
@@ -111,7 +112,8 @@ public class OrderJob {
 				} else {
 					Date programEnd = new Date();
 					long ms = programEnd.getTime() - programStart.getTime();
-					log.info("Method finished after {} seconds of working", (ms / 1000L));
+					log.info("Method [getOrders()] finished after [{}] sec of working",
+							(ms / 1000L));
 					executorService.shutdown();
 				}
 			}
@@ -123,6 +125,7 @@ public class OrderJob {
 	//	@Scheduled(fixedDelay = 1000000L, initialDelay = 0)
 	public void getAvailableDocs() throws IOException {
 		
+		log.info("Method [getAvailableDocs()] started to work");
 		Date programStart = new Date();
 		
 		/* STEP ONE
@@ -146,15 +149,11 @@ public class OrderJob {
 			
 			@Override
 			public void run() {
-				log.info("Starting cycle of updating documents at {} element of {}",
-						count + 1, byBase64Null.size());
-				
 				Document document = byBase64Null.get(count);
 				
 				if (count <= byBase64Null.size()) {
 					try {
-						log.info(
-								"Starting cycle of updating documents at {} element of {}",
+						log.info("Starting cycle of updating documents at [{}] of [{}]",
 								count + 1, byBase64Null.size());
 						
 						log.info("Current document to update: [ID: {}, TYPE:{}, UID: "
@@ -180,7 +179,7 @@ public class OrderJob {
 						try {
 							Response<DocumentResponse> docResponse =
 									availableDoc.execute();
-							log.info("Got the response in {} ms",
+							log.info("Got the response in [{}] sec",
 									(new Date().getTime() - start.getTime()) / 1000.);
 							
 							if (!docResponse.isSuccessful()) {
@@ -199,9 +198,8 @@ public class OrderJob {
 						}
 						
 						count++;
-						log.info(
-								"Scheduled method \"getAvailableDocs()\" ended process on "
-										+ "doc {} of {}", count, byBase64Null.size());
+						log.info("Scheduled method [getAvailableDocs()] ended process on "
+								+ "doc {} of {}", count, byBase64Null.size());
 					} catch (IOException e) {
 						log.error(e.getMessage());
 					}
@@ -209,7 +207,8 @@ public class OrderJob {
 					
 					Date programEnd = new Date();
 					long ms = programEnd.getTime() - programStart.getTime();
-					log.info("Method finished after {} seconds of working", (ms / 1000L));
+					log.info("Method [getAvailableDocs()] finished after [{}] sec of "
+							+ "working", (ms / 1000L));
 					executorService.shutdown();
 				}
 			}

--- a/src/main/java/com/dellin/mondoc/model/entity/Document.java
+++ b/src/main/java/com/dellin/mondoc/model/entity/Document.java
@@ -21,13 +21,14 @@ import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
 @Getter
 @Setter
 @Entity
-@Table(name = "documents")
+@Table(name = "documents", indexes = @Index(name = "idx_uid", columnList = "doc_uid"))
 @AllArgsConstructor
 @NoArgsConstructor
 @FieldDefaults(level = AccessLevel.PRIVATE)

--- a/src/main/java/com/dellin/mondoc/model/entity/Order.java
+++ b/src/main/java/com/dellin/mondoc/model/entity/Order.java
@@ -20,6 +20,7 @@ import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.ManyToOne;
 import javax.persistence.NamedAttributeNode;
 import javax.persistence.NamedEntityGraph;
@@ -29,7 +30,8 @@ import javax.persistence.Table;
 @Getter
 @Setter
 @Entity
-@Table(name = "orders")
+@Table(name = "orders",
+	   indexes = @Index(name = "idx_uid", columnList = "uid", unique = true))
 @AllArgsConstructor
 @NoArgsConstructor
 @FieldDefaults(level = AccessLevel.PRIVATE)

--- a/src/main/java/com/dellin/mondoc/service/impl/OrderServiceImpl.java
+++ b/src/main/java/com/dellin/mondoc/service/impl/OrderServiceImpl.java
@@ -139,8 +139,8 @@ public class OrderServiceImpl implements OrderService {
 						Date start = new Date();
 						log.info("Sending request to API");
 						Response<OrderResponse> response = orders.execute();
-						log.info("Got the response in {} ms",
-								(new Date().getTime() - start.getTime()) / 1000.);
+						long responseTime = new Date().getTime() - start.getTime();
+						log.info("Got the response in {} sec", responseTime / 1000.);
 						
 						assert response.body() != null;
 						Collection<OrderResponse.Order> ord = response.body().getOrders();
@@ -151,8 +151,9 @@ public class OrderServiceImpl implements OrderService {
 						log.info("End of page: [{}]. Total pages: [{}]", currentPage,
 								response.body().getMetadata().getTotalPages());
 						currentPage++;
-						
-						Thread.sleep(10000L);
+						long timeout = 10000L - responseTime;
+						log.info("Timeout before next request {} sec", timeout / 1000.);
+						Thread.sleep(timeout);
 					} catch (InterruptedException | IOException e) {
 						log.error(e.getMessage());
 						thread.interrupt();


### PR DESCRIPTION
Order, Document
- In order to get better and faster database search decided to make uid fields in both entities indexed. It becomes possible also because of editing request timeout. As we know, indexing increases the time it takes to write, update, and delete data in a table, because the database must update the index on every change. But we should have a recommended delay between request about 10 sec. So, I rewrote the delay time for the remainder between 10 seconds and the time to complete the request

OrderServiceImpl
- Change request timeout

OrderJob
- Edit logging